### PR TITLE
Adding blur customization

### DIFF
--- a/lib/v-blur.js
+++ b/lib/v-blur.js
@@ -10,7 +10,7 @@ function applyBlur (el, value) {
   if (!value) {
     return setBlur(el, 1, 'none', '')
   }
-  
+
   if (value === true) {
     return setBlur(el)
   }

--- a/lib/v-blur.js
+++ b/lib/v-blur.js
@@ -6,28 +6,29 @@ function setBlur(el, opacity = 0.5, filter = 1.5, transition = 'all .2s linear')
   el.style.transition = transition
 }
 
-function applyBlur(el, binding) {
-  if (!binding.value) {  
+function applyBlur(el, value) {
+  if (!value) {  
     return setBlur(el, 1, 'none', '')
   }
   
-  if (binding.value === true ) { 
+  if (value === true ) { 
     return setBlur(el) 
   }
 
-  if (typeof binding.value !== 'object') {
+  if (typeof value !== 'object') {
     throw new Error('Invalid type argument')
   }
 
-  setBlur(el, binding.value);
+  setBlur(el, value.opacity, value.filter, value.transition);
 }
 
 directive.bind = function (el, binding) {
-  applyBlur(el, binding)
+  applyBlur(el, binding.value)
 }
 
 directive.update = function (el, binding) {
-  applyBlur(el, binding)
+  if (binding.value === binding.oldValue) { return }
+  applyBlur(el, binding.value)
 }
 
 export default directive

--- a/lib/v-blur.js
+++ b/lib/v-blur.js
@@ -22,6 +22,10 @@ function applyBlur(el, binding) {
   setBlur(el, binding.value);
 }
 
+directive.bind = function (el, binding) {
+  applyBlur(el, binding)
+}
+
 directive.update = function (el, binding) {
   applyBlur(el, binding)
 }

--- a/lib/v-blur.js
+++ b/lib/v-blur.js
@@ -1,9 +1,29 @@
 const directive = {}
 
+function setBlur(el, opacity = 1, filter = 1.5, transition = 'all .2s linear') {
+  el.style.opacity = opacity
+  el.style.filter = filter === 'none' ? filter : `blur(${filter}px)`
+  el.style.transition = transition
+}
+
+function applyBlur(el, binding) {
+  if (!binding.value) {  
+    return setBlur(el, 1, 'none', '')
+  }
+  
+  if (binding.value === true ) { 
+    return setBlur(el) 
+  }
+
+  if (typeof binding.value !== 'object') {
+    throw new Error('Invalid type argument')
+  }
+
+  setBlur(el, binding.value);
+}
+
 directive.update = function (el, binding) {
-  el.style.opacity = binding.value ? 0.5 : 1
-  el.style.filter = binding.value ? 'blur(1.5px)' : 'none'
-  el.style.transition = 'all .2s linear'
+  applyBlur(el, binding)
 }
 
 export default directive

--- a/lib/v-blur.js
+++ b/lib/v-blur.js
@@ -1,25 +1,25 @@
 const directive = {}
 
-function setBlur(el, opacity = 0.5, filter = 1.5, transition = 'all .2s linear') {
+function setBlur (el, opacity = 0.5, filter = 1.5, transition = 'all .2s linear') {
   el.style.opacity = opacity
   el.style.filter = filter === 'none' ? filter : `blur(${filter}px)`
   el.style.transition = transition
 }
 
-function applyBlur(el, value) {
-  if (!value) {  
+function applyBlur (el, value) {
+  if (!value) {
     return setBlur(el, 1, 'none', '')
   }
   
-  if (value === true ) { 
-    return setBlur(el) 
+  if (value === true) {
+    return setBlur(el)
   }
 
   if (typeof value !== 'object') {
     throw new Error('Invalid type argument')
   }
 
-  setBlur(el, value.opacity, value.filter, value.transition);
+  setBlur(el, value.opacity, value.filter, value.transition)
 }
 
 directive.bind = function (el, binding) {

--- a/lib/v-blur.js
+++ b/lib/v-blur.js
@@ -1,6 +1,6 @@
 const directive = {}
 
-function setBlur(el, opacity = 1, filter = 1.5, transition = 'all .2s linear') {
+function setBlur(el, opacity = 0.5, filter = 1.5, transition = 'all .2s linear') {
   el.style.opacity = opacity
   el.style.filter = filter === 'none' ? filter : `blur(${filter}px)`
   el.style.transition = transition

--- a/test/v-blur.test.js
+++ b/test/v-blur.test.js
@@ -3,8 +3,50 @@
 import directive from '../lib/v-blur'
 
 describe('v-blur -> directive', () => {
+  it('it has an bind method available', () => {
+    expect(typeof directive.bind).toBe('function')
+  })
+
   it('it has an update method available', () => {
     expect(typeof directive.update).toBe('function')
+  })
+
+  describe('bind', () => {
+    it('adds a filter, transition and an opacity style if the value is truthy', () => {
+      const bind = directive.bind
+      const div = document.createElement('div')
+
+      bind(div, { value: true })
+
+      expect(div.style.opacity, 0.5)
+      expect(div.style.filter, 'blur(1.5px)')
+      expect(div.style.transition, 'all .2s linear')
+    })
+
+    it('adds a filter, transition and an opacity style according config argumet', () => {
+      const bind = directive.bind
+      const div = document.createElement('div')
+
+      const opacity = 0.1
+      const filter = 2
+
+      bind(div, { value: { opacity, filter } })
+
+      expect(div.style.opacity, opacity)
+      expect(div.style.filter, `blur(${filter}px)`)
+      expect(div.style.transition, 'all .2s linear')
+    })
+
+    it('adds a transition and remove the filter and opacity style if the value is falsy', () => {
+      const bind = directive.bind
+      const div = document.createElement('div')
+
+      bind(div, { value: false })
+
+      expect(div.style.opacity, 1)
+      expect(div.style.filter, 'none')
+      expect(div.style.transition, 'all .2s linear')
+    })
   })
 
   describe('update', () => {
@@ -16,6 +58,20 @@ describe('v-blur -> directive', () => {
 
       expect(div.style.opacity, 0.5)
       expect(div.style.filter, 'blur(1.5px)')
+      expect(div.style.transition, 'all .2s linear')
+    })
+
+    it('adds a filter, transition and an opacity style according config argumet', () => {
+      const update = directive.update
+      const div = document.createElement('div')
+
+      const opacity = 0.1
+      const filter = 2
+
+      update(div, { value: { opacity, filter } })
+
+      expect(div.style.opacity, opacity)
+      expect(div.style.filter, `blur(${filter}px)`)
       expect(div.style.transition, 'all .2s linear')
     })
 


### PR DESCRIPTION
# Adding blur customization

> This PR adds blur customization support and is compatible with previous version. The directive now expects a `Boolean` or an `Object` with this properties:

```javascript
{
  opacity: Number // default 0.5,
  filter: Number // default 1.5,
  transition: String // default all .2s linear
}
```

I also added the `bind` hook to avoid issues when you set static or default values.

### Examples
```html

<!-- Boolean Support -->
<div v-blur="false"></div> <!-- disabling blur -->
<div v-blur="true"></div> <!-- blur with default values: opacity: 0.5; filter: blur(1.5px), transition: ''all .2s linear' -->

<!-- Object Support -->
<div v-blur="{ opacity: 0.6, filter: 2.4, transition: 'all 1s linear' }"></div>
<div v-blur="{ opacity: 0.6, filter: 2.4 }"></div>
<div v-blur="{ opacity: 0.3 } "></div>
<div v-blur="{ filter: 1 } "></div>
```