### PR TITLE
Improve object binding value usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![bitHound Code](https://www.bithound.io/github/ndelvalle/v-blur/badges/code.svg)](https://www.bithound.io/github/ndelvalle/v-blur)
 
 
-Vue directive to blur a specific element dynamically
+Vue directive to blur an element dynamically. Useful to partially hide elements, use it with a spinner when content is not ready among other things.
 
 ## Install
 
@@ -19,7 +19,18 @@ $ npm install --save v-blur
 ```bash
 $ yarn add v-blur
 ```
+## Binding value
 
+The binding value can be a Boolean or an Object. If a Boolean is provided, the directive uses default values for [opacity](https://www.w3schools.com/cssref/css3_pr_opacity.asp), [filter](https://www.w3schools.com/jsref/prop_style_filter.asp) and [transition](https://www.w3schools.com/jsref/prop_style_transition.asp). To use a custom configuration, an object with these attributes plus `isBlurred` (To determine when to apply these styles) can be provided.
+
+### Binding object attributes
+
+| option     | default          | type   |
+| -----------|:----------------:| ------:|
+| isBlurred  | false            | boolean|
+| opacity    | 0.5              | number |
+| filter     | 'blur(1.5px)'    | string |
+| transition | 'all .2s linear' | string |
 
 ## Use
 
@@ -35,7 +46,14 @@ Vue.use(vBlur)
   export default {
       data () {
         return {
-          isBlurred: true
+          isBlurred: true, // activate and deactivate blur directive example 1
+          
+          blurConfig: {
+            isBlurred: false, // activate and deactivate blur directive example 2
+            opacity: 0.3,
+            filter: 'blur(1.2px)',
+            transition: 'all .3s linear'
+          }
         }
       }
     }
@@ -43,7 +61,11 @@ Vue.use(vBlur)
 </script>
 
 <template>
+  <!-- Example 1 using just a boolean (Uses default values) -->
   <div v-blur="isBlurred"></div>
+
+  <!-- Example 2 using just an object (Uses config values) -->
+  <div v-blur="blurConfig"></div>
 </template>
 ```
 

--- a/lib/v-blur.js
+++ b/lib/v-blur.js
@@ -1,34 +1,33 @@
 const directive = {}
 
-function setBlur (el, opacity = 0.5, filter = 1.5, transition = 'all .2s linear') {
-  el.style.opacity = opacity
-  el.style.filter = filter === 'none' ? filter : `blur(${filter}px)`
+directive.blur = function (el, bindingValue) {
+  if (typeof bindingValue !== 'boolean' && typeof bindingValue !== 'object') {
+    throw new Error(
+      'Expected directive binding value type to be a boolean or an object but found ' +
+      `a ${typeof bindingValue} instead`
+    )
+  }
+
+  if (typeof bindingValue === 'boolean') {
+    bindingValue = { isBlurred: bindingValue }
+  }
+
+  const opacity = bindingValue.opacity || 0.5
+  const filter = bindingValue.filter || 'blur(1.5px)'
+  const transition = bindingValue.transition || 'all .2s linear'
+
+  el.style.opacity = bindingValue.isBlurred ? opacity : 1
+  el.style.filter = bindingValue.isBlurred ? filter : 'none'
   el.style.transition = transition
 }
 
-function applyBlur (el, value) {
-  if (!value) {
-    return setBlur(el, 1, 'none', '')
-  }
-
-  if (value === true) {
-    return setBlur(el)
-  }
-
-  if (typeof value !== 'object') {
-    throw new Error('Invalid type argument')
-  }
-
-  setBlur(el, value.opacity, value.filter, value.transition)
-}
-
 directive.bind = function (el, binding) {
-  applyBlur(el, binding.value)
+  directive.blur(el, binding.value)
 }
 
 directive.update = function (el, binding) {
   if (binding.value === binding.oldValue) { return }
-  applyBlur(el, binding.value)
+  directive.blur(el, binding.value)
 }
 
 export default directive

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.2",
   "description": "Simple Vue directive to blur a specific element",
   "author": "ndelvalle <nicolas.delvalle@gmail.com>",
+  "contributors": [
+    "Ignacio Anaya <ignacio.anaya89@gmail.com>"
+  ],
   "main": "dist/v-blur.min.js",
   "scripts": {
     "test": "jest --coverage",

--- a/test/v-blur.test.js
+++ b/test/v-blur.test.js
@@ -1,4 +1,4 @@
-/* global describe it expect */
+/* global describe, it, expect */
 
 import directive from '../lib/v-blur'
 
@@ -12,7 +12,7 @@ describe('v-blur -> directive', () => {
   })
 
   describe('bind', () => {
-    it('adds a filter, transition and an opacity style if the value is truthy', () => {
+    it('adds a default filter, transition and an opacity style if the binding value is truthy', () => {
       const bind = directive.bind
       const div = document.createElement('div')
 
@@ -23,21 +23,7 @@ describe('v-blur -> directive', () => {
       expect(div.style.transition, 'all .2s linear')
     })
 
-    it('adds a filter, transition and an opacity style according config argumet', () => {
-      const bind = directive.bind
-      const div = document.createElement('div')
-
-      const opacity = 0.1
-      const filter = 2
-
-      bind(div, { value: { opacity, filter } })
-
-      expect(div.style.opacity, opacity)
-      expect(div.style.filter, `blur(${filter}px)`)
-      expect(div.style.transition, 'all .2s linear')
-    })
-
-    it('adds a transition and remove the filter and opacity style if the value is falsy', () => {
+    it('removes default filter and an opacity style if the binding value is falsy', () => {
       const bind = directive.bind
       const div = document.createElement('div')
 
@@ -47,10 +33,40 @@ describe('v-blur -> directive', () => {
       expect(div.style.filter, 'none')
       expect(div.style.transition, 'all .2s linear')
     })
+
+    it('adds custom filter, transition and an opacity style if the binding value is an object and isBlurred attribute is truthy', () => {
+      const bind = directive.bind
+      const div = document.createElement('div')
+
+      const opacity = 0.1
+      const filter = 'blur(2px)'
+      const isBlurred = true
+
+      bind(div, { value: { opacity, filter, isBlurred } })
+
+      expect(div.style.opacity, opacity)
+      expect(div.style.filter, filter)
+      expect(div.style.transition, 'all .2s linear')
+    })
+
+    it('removes custom filter and opacity style if the binding value is an object and isBlurred attribute is falsy', () => {
+      const bind = directive.bind
+      const div = document.createElement('div')
+
+      const opacity = 0.1
+      const filter = 'blur(2px)'
+      const isBlurred = false
+
+      bind(div, { value: { opacity, filter, isBlurred } })
+
+      expect(div.style.opacity, 1)
+      expect(div.style.filter, 'none')
+      expect(div.style.transition, 'all .2s linear')
+    })
   })
 
   describe('update', () => {
-    it('adds a filter, transition and an opacity style if the value is truthy', () => {
+    it('adds a default filter, transition and an opacity style if the binding value is truthy', () => {
       const update = directive.update
       const div = document.createElement('div')
 
@@ -61,25 +77,41 @@ describe('v-blur -> directive', () => {
       expect(div.style.transition, 'all .2s linear')
     })
 
-    it('adds a filter, transition and an opacity style according config argumet', () => {
-      const update = directive.update
-      const div = document.createElement('div')
-
-      const opacity = 0.1
-      const filter = 2
-
-      update(div, { value: { opacity, filter } })
-
-      expect(div.style.opacity, opacity)
-      expect(div.style.filter, `blur(${filter}px)`)
-      expect(div.style.transition, 'all .2s linear')
-    })
-
-    it('adds a transition and remove the filter and opacity style if the value is falsy', () => {
+    it('removes default filter and an opacity style if the binding value is falsy', () => {
       const update = directive.update
       const div = document.createElement('div')
 
       update(div, { value: false })
+
+      expect(div.style.opacity, 1)
+      expect(div.style.filter, 'none')
+      expect(div.style.transition, 'all .2s linear')
+    })
+
+    it('adds custom filter, transition and an opacity style if the binding value is an object and isBlurred attribute is truthy', () => {
+      const update = directive.update
+      const div = document.createElement('div')
+
+      const opacity = 0.1
+      const filter = 'blur(2px)'
+      const isBlurred = true
+
+      update(div, { value: { opacity, filter, isBlurred } })
+
+      expect(div.style.opacity, opacity)
+      expect(div.style.filter, filter)
+      expect(div.style.transition, 'all .2s linear')
+    })
+
+    it('removes custom filter and opacity style if the binding value is an object and isBlurred attribute is falsy', () => {
+      const update = directive.update
+      const div = document.createElement('div')
+
+      const opacity = 0.1
+      const filter = 'blur(2px)'
+      const isBlurred = false
+
+      update(div, { value: { opacity, filter, isBlurred } })
 
       expect(div.style.opacity, 1)
       expect(div.style.filter, 'none')


### PR DESCRIPTION
This PR aims to make the directive more configurable like suggested in #1 picking up the contribution of @ianaya89 and adding the `isBlurred` attribute to the config object.

Usage example:

```javascript
<script>
  export default {
      data () {
        return {
          isBlurred: true,
          
          blurConfig: {
            isBlurred: false,
            opacity: 0.3,
            filter: 'blur(1.2px)',
            transition: 'all .3s linear'
          }
        }
      }
    }
  };
</script>

<template>
  <div v-blur="isBlurred"></div>
  <div v-blur="blurConfig"></div>
</template>
```